### PR TITLE
Fix shebang

### DIFF
--- a/converter/motionarea.py
+++ b/converter/motionarea.py
@@ -10,6 +10,7 @@ from types import ModuleType
 from typing import List, Optional, Tuple
 
 from converter.indent import Indenter
+from pmac_motorhome._version_git import __version__
 
 from .pipemessage import IPC_FIFO_NAME, get_message
 from .shim.plc import PLC
@@ -353,8 +354,8 @@ class MotionArea:
 
     def get_shebang(self):
         # get the python path for shebang
-        python_path = subprocess.check_output("which python", shell=True).strip()
-        python_path = python_path.decode("utf-8")
+        module_path_elements = ['/dls_sw','prod','python3', 'RHEL7-x86_64','pmac_motorhome', __version__, 'lightweight-venv', 'bin','python3']
+        python_path = '/'.join(module_path_elements)
         text = f"#!/bin/env {python_path}"
         return text
 

--- a/tests/unittests/converter/test_motionarea.py
+++ b/tests/unittests/converter/test_motionarea.py
@@ -3,15 +3,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from converter.motionarea import MotionArea
+from pmac_motorhome._version_git import __version__
 
 
 class TestMotionArea(unittest.TestCase):
-    @patch("subprocess.check_output")
-    def test_shebang_looks_as_expected(self, mock_subprocess):
+    def test_shebang_looks_as_expected(self):
         # Arrange
-        python_path = "/bin/python"
-        expected_shebang = "#!/bin/env /bin/python"
-        mock_subprocess.return_value = python_path.encode("UTF-8")
+        expected_shebang = "#!/bin/env /dls_sw/prod/python3/RHEL7-x86_64/pmac_motorhome/"+__version__+"/lightweight-venv/bin/python3"
         motionarea = MotionArea(Path("/tmp"))
         # Act
         content = motionarea.get_shebang()


### PR DESCRIPTION
Changed get_shebang function in the converter /motionarea.py - it now includes path to the released version of pmac_motorhome.
Parts of the path are hard-coded and Diamond specific - should be fine assuming the converter is only ever going to be used at Diamond.