### PR TITLE
the old generating script should use python2

### DIFF
--- a/converter/motionarea.py
+++ b/converter/motionarea.py
@@ -254,7 +254,7 @@ class MotionArea:
 
                     # use _execute_script with python2
                     self._execute_script(
-                        gen, brick_folder, pypath, str(plc_file), python2=False
+                        gen, brick_folder, pypath, str(plc_file), python2=True
                     )
 
                     # collect objects from pipe

--- a/converter/shim/controllertype.py
+++ b/converter/shim/controllertype.py
@@ -1,0 +1,9 @@
+class ControllerType():
+    """
+    Defines the types of controller supported
+    """
+
+    #: Geobrick controller
+    brick = "ControllerType.brick"
+    #: VME PMAC Controller
+    pmac = "ControllerType.pmac"

--- a/converter/shim/globals.py
+++ b/converter/shim/globals.py
@@ -1,6 +1,6 @@
 # from typing import Callable, Optional
 
-from pmac_motorhome.constants import ControllerType
+from converter.shim.controllertype import ControllerType
 from pmac_motorhome.sequences import (
     home_home,
     home_hsw,


### PR DESCRIPTION
The old generating script should be run using python2.
Python2 which we use for conversion doesn't have Enum - hence the shim/globals change